### PR TITLE
Improve Test Coverage Reporting and Cleanup Reliability

### DIFF
--- a/test/local_test_runner/lib/_nested-docker-cleanup.bash
+++ b/test/local_test_runner/lib/_nested-docker-cleanup.bash
@@ -72,25 +72,3 @@ nested_container_cleanup() {
         echo "✅ No test container to clean up."
     fi
 }
-
-
-cleanup_test_device() {
-    echo "🧹 Cleaning up loopback device and image file..."
-
-    if losetup -j "${CONFIG[TEST_FILE]}" | grep -q "${CONFIG[TEST_DEVICE]}"; then
-        echo "Detaching loop device ${CONFIG[TEST_DEVICE]}..."
-        losetup -d "${CONFIG[TEST_DEVICE]}" || echo "❌ Failed to detach loop device"
-    fi
-
-    if [[ -f "${CONFIG[TEST_FILE]}" ]]; then
-        echo "Removing image file ${CONFIG[TEST_FILE]}..."
-        rm -f "${CONFIG[TEST_FILE]}" || echo "❌ Failed to remove image file"
-    fi
-
-    if [[ -b "${CONFIG[TEST_DEVICE]}" || -e "${CONFIG[TEST_FILE]}" ]]; then
-        echo "❌ Failed Test Device Cleanup"
-        return 1
-    fi
-
-    echo "✅ Cleanup complete."
-}

--- a/test/local_test_runner/lib/_run-in-docker.bash
+++ b/test/local_test_runner/lib/_run-in-docker.bash
@@ -81,7 +81,7 @@ cleanup_test_device() {
         rm -f "${CONFIG[TEST_FILE]}" || echo "❌ Failed to remove image file"
     fi
 
-    if [[ -b "${CONFIG[TEST_DEVICE]}" || -e "${CONFIG[TEST_FILE]}" ]]; then
+    if losetup -l | grep -q "${CONFIG[TEST_DEVICE]}" || [[ -f "${CONFIG[TEST_FILE]}" ]]; then
         echo "❌ Failed Test Device Cleanup"
         return 1
     fi
@@ -127,4 +127,5 @@ run_in_docker() {
     # Ensure the test container is properly cleaned up after execution
     docker exec "${CONFIG[DIND_CONTAINER]}" docker stop "$CONTAINER_ID" > /dev/null 2>&1
     docker exec "${CONFIG[DIND_CONTAINER]}" docker rm -f "$CONTAINER_ID" > /dev/null 2>&1
+    cleanup_test_device
 }

--- a/test/local_test_runner/lib/_run-test.bash
+++ b/test/local_test_runner/lib/_run-test.bash
@@ -76,14 +76,16 @@ run_test() {
         run_in_docker "bats '${CONFIG[BATS_FLAGS]}' '${test_file}'"
     fi
 
-    # Run kcov if --coverage was passed
+    # Run kcov if --coverage was passed to local_test_runner/runner.bash
     if [[ "${CONFIG[COVERAGE]}" == "true" ]]; then
         echo "📊 Running coverage analysis..."
+
+        # Run coverage analysis inside the test container
         run_in_docker "kcov_dir=\$(mktemp -d) && \
-                       echo '📂 Temporary kcov directory: \$kcov_dir' && \
-                       kcov --clean --include-path='${source_file}' \"\$kcov_dir\" bats '${test_file}' && \
-                       echo '📝 Uncovered lines:' && \
-                       grep 'covered=\"false\"' \"\$kcov_dir/bats/sonarqube.xml\" || echo '✅ All lines covered.' && \
+                       kcov --clean --include-path='${source_file}' \"\$kcov_dir\" bats '${test_file}' > /dev/null 2>&1 && \
+                       grep 'covered=\"false\"' \"\$kcov_dir/bats/sonarqube.xml\" | \
+                       sed -n 's/.*lineNumber=\"\([0-9]*\)\".*/📍 Line \1 uncovered/p' || \
+                       echo '✅ All lines covered.' && \
                        rm -rf \"\$kcov_dir\""
     fi
 

--- a/test/local_test_runner/runner.bash
+++ b/test/local_test_runner/runner.bash
@@ -69,20 +69,9 @@ load_libraries() {
     source "$BASEDIR/test/local_test_runner/lib/_nested-docker-cleanup.bash"
 }
 
-file_check() {
-    local source_file="$1"
-    local test_file="$2"
-
-    # Fail if either file is missing
-    [[ -f "$source_file" && -f "$test_file" ]] || {
-        echo "❌ ERROR: One or more required files are missing:" >&2
-        [[ -f "$source_file" ]] || echo "   - ❌ Missing: $source_file" >&2
-        [[ -f "$test_file" ]] || echo "   - ❌ Missing: $test_file" >&2
-        return 1
-    }
-}
 
 test_dind_container() {
+    # this is manual debugging test
     # Ensure DinD is running
     start_dind
 
@@ -133,6 +122,7 @@ test_dind_container() {
 }
 
 test_container() {
+    # this is manual debugging test
     # Ensure DinD is running
     start_dind
 
@@ -175,6 +165,7 @@ test_container() {
 
 # bash test/local_test_runner/runner.bash --test manual_nested_container
 manual_nested_container() {
+    # this is manual debugging test
     docker exec -it "${CONFIG[DIND_CONTAINER]}" docker run --rm -it \
         --privileged --user root \
         --cap-add=MKNOD \
@@ -272,6 +263,20 @@ integration_test_parser() {
 
     run_test "$source_file" "$test_file" "$workflow_event" "$workflow_job"
 
+}
+
+
+file_check() {
+    local source_file="$1"
+    local test_file="$2"
+
+    # Fail if either file is missing
+    [[ -f "$source_file" && -f "$test_file" ]] || {
+        echo "❌ ERROR: One or more required files are missing:" >&2
+        [[ -f "$source_file" ]] || echo "   - ❌ Missing: $source_file" >&2
+        [[ -f "$test_file" ]] || echo "   - ❌ Missing: $test_file" >&2
+        return 1
+    }
 }
 
 main() {

--- a/test/local_test_runner/unit/test_device_fixture/test_setup_luks.bats
+++ b/test/local_test_runner/unit/test_device_fixture/test_setup_luks.bats
@@ -56,6 +56,7 @@ function teardown {
     run setup_luks
     assert_success
     assert_output --partial "LUKS container created and opened at ${DEVCONFIG[MAPPED_DEVICE]}"
+    refute_output --partial "ERROR: ${DEVCONFIG[TEST_DEVICE]} is not a valid block device."
 }
 
 @test "setup_luks() correctly mutates array: DEVCONFIG and file: REG_FILE" {

--- a/test/local_test_runner/unit/test_device_fixture/test_teardown_device.bats
+++ b/test/local_test_runner/unit/test_device_fixture/test_teardown_device.bats
@@ -4,7 +4,7 @@ function setup {
     load '../../../lib/_common_setup'
     _common_setup
     source "test/local_test_runner/lib/_device_fixture.bash"
-    create_device
+    register_test_device
     setup_luks
     setup_lvm
     format_filesystem


### PR DESCRIPTION
# Description
This PR introduces significant improvements to test coverage reporting and cleanup reliability within the test suite. The primary enhancements include cumulative uncovered line filtering, improved teardown validation, and more robust test assertions. Additionally, unnecessary debug output has been suppressed for better readability.

## Key Changes
- **Enhanced Test Coverage Reporting**
  - Introduced `filter_uncovered_lines()` to track and filter uncovered lines dynamically across multiple test runs.
  - Implemented `test_device_fixture()` to aggregate coverage data from multiple test cases.
  - Standardized coverage reporting for better visibility and debugging.

- **Improved Cleanup and Teardown Reliability**
  - Ensured loop devices are fully detached before validation (`losetup -l | grep -q`).
  - Improved filesystem unmounting by adding read-only remounts and process termination checks (`fuser -km`).
  - Added explicit success messages for LVM, LUKS, and loop device cleanup steps.
  - Standardized teardown messaging for consistency and debugging clarity.

- **Refinements and Fixes**
  - Suppressed unnecessary debug logs, including LVM messages and leaked file descriptors.
  - Removed unused `print_devconfig()` function.
  - Fixed minor typos and improved function placement for maintainability.

## Closes Issues
- Closes #10: Ensures loop device cleanup validation is accurate and prevents false failures.

## How to Test
1. Run `bash test/local_test_runner/runner.bash --test test_device_fixture --coverage` to verify cumulative uncovered line filtering.
2. Execute `bash test/local_test_runner/runner.bash --test test_device_fixture_teardown_device` to validate improved cleanup and teardown processes.
3. Review test logs to confirm suppressed debug output and clearer teardown messaging.

This PR significantly enhances test reliability and maintainability while improving visibility into coverage gaps.

- **feat(test-runner): improve coverage reporting and suppress noisy output**
- **relocate file_check() to near the end of the file, local_test_runner/runner.bash**
- **fix typo: create_device to register_test_device**
- **test(teardown_device): enhance test assertions for teardown process**
- **test(setup_luks): refute output that the block device is invalid**
- **test device cleanup exists in _run-in-docker.bash**
- **fix(cleanup): ensure loop device is fully detached before validation**
- **fix(teardown_device): improve cleanup reliability and add detailed status messages**
- **feat(coverage): add cumulative uncovered lines filtering for test suites**
