### PR TITLE
systemd test suite migration: replace inner harness with ephemeral systemd container

### DIFF
--- a/.github/workflows/test_parser.yaml
+++ b/.github/workflows/test_parser.yaml
@@ -24,7 +24,7 @@ jobs:
   unit-test-parser:
     runs-on: ubuntu-latest
     container:
-      image: robertportelli/readiluks-inner-harness:latest
+      image: robertportelli/readiluks-inner-systemd:latest
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -48,7 +48,7 @@ jobs:
   integration-test-parser:
     runs-on: ubuntu-latest
     container:
-      image: robertportelli/readiluks-inner-harness:latest
+      image: robertportelli/readiluks-inner-systemd:latest
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4

--- a/.github/workflows/test_test_environment.yaml
+++ b/.github/workflows/test_test_environment.yaml
@@ -12,7 +12,7 @@ jobs:
   test-bats-common-setup:
     runs-on: ubuntu-latest
     container:
-      image: robertportelli/readiluks-inner-harness:latest
+      image: robertportelli/readiluks-inner-systemd:latest
       options: --user root
     steps:
       - name: Check out Code

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 build-inner-systemd:
 	docker buildx build --load \
-		-t robertportelli/readiluks-systemd-inner:latest \
-		-f docker/test/Dockerfile.inner-harness-harness-systemd .
+		-t robertportelli/readiluks-inner-systemd:latest \
+		-f docker/test/Dockerfile.inner-systemd .
 
 # 🌳 Show project structure
 tree:

--- a/docker/test/Dockerfile.inner-systemd
+++ b/docker/test/Dockerfile.inner-systemd
@@ -2,8 +2,24 @@ FROM archlinux:base
 
 ENV container=docker
 
-RUN pacman -Syu --noconfirm systemd systemd-libs iproute2 iputils \
-    && pacman -Scc --noconfirm
+# Initialize and update keyring before running a full system upgrade
+RUN pacman-key --init && \
+    pacman-key --populate archlinux && \
+    pacman -Sy --noconfirm archlinux-keyring && \
+    pacman -Syu --noconfirm
+
+# Install required packages
+RUN pacman -S --noconfirm --needed \
+    act \
+    bats-assert bats-file bats-support \
+    nodejs npm \
+    kcov \
+    git \
+    lvm2 \
+    btrfs-progs \
+    parallel
+
+RUN pacman -Scc --noconfirm
 
 # Prepare for systemd boot
 STOPSIGNAL SIGRTMIN+3

--- a/test/local_test_runner/lib/_manage_outer_docker.bash
+++ b/test/local_test_runner/lib/_manage_outer_docker.bash
@@ -75,9 +75,9 @@ start_outer_container() {
 
     echo "✅ ${CONFIG[OUTER_CONTAINER]} is ready!"
 
-    load_harness_image
+    #load_harness_image
     load_systemd_image
-    start_systemd_container
+    #start_systemd_container
 }
 
 start_systemd_container() {

--- a/test/local_test_runner/lib/_run-inner-sysd.bash
+++ b/test/local_test_runner/lib/_run-inner-sysd.bash
@@ -1,0 +1,170 @@
+# ==============================================================================
+# Filename: test/local_test_runner/lib/_run-inner-sysd.bash
+# ------------------------------------------------------------------------------
+# Description:
+#   Manages the execution of an ephemeral systemd-based test container inside the
+#   outer Docker-in-Docker (DinD) environment. Handles the creation and cleanup of a
+#   loopback device on the host, which is passed through to the inner container for
+#   isolated block device testing.
+#
+# Purpose:
+#   - Starts a systemd container inside DinD for each test case.
+#   - Waits for systemd to become fully operational before running the test.
+#   - Creates a loopback device on the host using an image file to simulate a block device.
+#   - Passes the loopback device to the inner container for use in tests.
+#   - Executes the provided command inside the systemd container and prints output.
+#   - Stops and removes the container after execution to ensure clean state.
+#   - Cleans up the loopback device and temporary image file to prevent resource leakage.
+#
+# Functions:
+#   - create_test_device:
+#       Creates a temporary image file, sets up a loopback device, and stores its reference.
+#   - cleanup_test_device:
+#       Detaches the loopback device, removes the temporary image file, and validates cleanup.
+#   - run_systemd_container:
+#       Ensures DinD is running, verifies the systemd image exists, creates the test device,
+#       starts the container, waits for systemd readiness, runs the test command,
+#       and performs cleanup of the container and device.
+#
+# Usage:
+#   source "$BASEDIR/test/local_test_runner/lib/_run-inner-sysd.bash"
+#   run_systemd_container "<command>"
+#
+# Example:
+#   # Run a Bats test inside an ephemeral systemd container
+#   run_systemd_container "bats test/local_test_runner/unit/test_parser.bats"
+#
+# Requirements:
+#   - Requires `_manage_outer_docker.bash` to manage the outer DinD container.
+#   - Requires `_runner-config.bash` to initialize CONFIG with required image/container names.
+#   - Docker must be installed and accessible on the host.
+#   - Assumes the outer DinD container will launch if not already running.
+#
+# Author:
+#   Robert Portelli
+#   Repository: https://github.com/robert-portelli/readiluks
+#
+# Version:
+#   See repository tags or release notes.
+#
+# License:
+#   See LICENSE.md in the repository.
+#   See commit history via `git log`.
+# ==============================================================================
+
+declare -gA INCONFIG=(
+    [TEST_FILE_SIZE]="1024M"
+    [TEST_FILES]=""
+    [TEST_DEVICES]=""
+)
+
+create_test_device() {
+    local img_file
+
+    img_file="/tmp/readiluks-test-device-file-$(uuidgen | cut -c -5).img"
+    truncate -s "${INCONFIG[TEST_FILE_SIZE]}" "$img_file"
+
+    # Create a loopback device on the host
+    local loop_device
+    loop_device=$(sudo losetup --show -fP "$img_file" 2>/dev/null)
+    if [[ -z "$loop_device" ]]; then
+        echo "❌ Failed to create loopback device. Aborting."
+        rm -f "$img_file"
+        exit 1
+    fi
+    echo "✅ Loopback device created: $loop_device"
+
+    INCONFIG[TEST_FILE]="$img_file"
+    INCONFIG[TEST_DEVICE]="$loop_device"
+
+}
+
+cleanup_test_device() {
+    echo "🧹 Cleaning up loopback device and image file..."
+
+    if losetup -j "${INCONFIG[TEST_FILE]}" | grep -q "${INCONFIG[TEST_DEVICE]}"; then
+        echo "Detaching loop device ${INCONFIG[TEST_DEVICE]}..."
+        losetup -d "${INCONFIG[TEST_DEVICE]}" || echo "❌ Failed to detach loop device"
+    fi
+
+    if [[ -f "${INCONFIG[TEST_FILE]}" ]]; then
+        echo "Removing image file ${INCONFIG[TEST_FILE]}..."
+        rm -f "${INCONFIG[TEST_FILE]}" || echo "❌ Failed to remove image file"
+    fi
+
+    if losetup -l | grep -q "${INCONFIG[TEST_DEVICE]}" || [[ -f "${INCONFIG[TEST_FILE]}" ]]; then
+        echo "❌ Failed Test Device Cleanup"
+        return 1
+    fi
+
+    echo "✅ Cleanup complete."
+}
+
+run_systemd_container() {
+    local cmd="$1"
+
+    # Ensure outer container (DinD) is running
+    start_outer_container
+
+    # Verify systemd image exists inside DinD
+    # shellcheck disable=SC2153
+    if ! docker exec "${CONFIG[OUTER_CONTAINER]}" docker images --format "{{.Repository}}:{{.Tag}}" |
+         grep -q "${CONFIG[SYSTEMD_IMAGE]}"; then
+        echo "❌ Image '${CONFIG[SYSTEMD_IMAGE]}' is missing inside ${CONFIG[OUTER_CONTAINER]}. Aborting."
+        exit 1
+    fi
+
+    create_test_device
+
+    echo "🚀 Starting ephemeral systemd container..."
+    local CONTAINER_ID
+    CONTAINER_ID=$(docker exec "${CONFIG[OUTER_CONTAINER]}" docker run -d \
+        --privileged \
+        --cgroupns=host \
+        --user "$(id -u):$(id -g)" \
+        --tmpfs /tmp --tmpfs /run --tmpfs /run/lock \
+        -v /sys/fs/cgroup:/sys/fs/cgroup:rw \
+        -v "${CONFIG[BASE_DIR]}:${CONFIG[BASE_DIR]}:ro" \
+        -v /var/run/docker.sock:/var/run/docker.sock \
+        --device="${INCONFIG[TEST_DEVICE]}" \
+        -e "TEST_DEVICE=${INCONFIG[TEST_DEVICE]}" \
+        -w "${CONFIG[BASE_DIR]}" \
+        "${CONFIG[SYSTEMD_IMAGE]}")
+
+    if [[ -z "$CONTAINER_ID" ]]; then
+        echo "❌ Failed to start systemd container inside DinD."
+        cleanup_test_device
+        exit 1
+    fi
+
+    echo "⏳ Waiting for systemd to become ready inside ephemeral container..."
+    for i in {1..10}; do
+        local status
+        status=$(docker exec "${CONFIG[OUTER_CONTAINER]}" \
+            docker exec "$CONTAINER_ID" systemctl is-system-running 2>/dev/null || true)
+
+        if [[ "$status" == "running" ]]; then
+            echo "✅ systemd is fully running in test container."
+            break
+        fi
+
+        echo "   ⌛ systemd state: ${status:-unavailable}, retrying ($i/10)..."
+        sleep 1
+    done
+
+    if [[ "$status" != "running" ]]; then
+        echo "❌ systemd failed to become ready inside test container."
+        docker exec "${CONFIG[OUTER_CONTAINER]}" docker rm -f "$CONTAINER_ID" >/dev/null 2>&1
+        cleanup_test_device
+        return 1
+    fi
+
+    echo "▶️ Running test command inside systemd container..."
+    docker exec "${CONFIG[OUTER_CONTAINER]}" \
+        docker exec "$CONTAINER_ID" bash -c "$cmd"
+
+    echo "🧼 Cleaning up container and loop device..."
+    docker exec "${CONFIG[OUTER_CONTAINER]}" docker stop "$CONTAINER_ID" >/dev/null 2>&1
+    docker exec "${CONFIG[OUTER_CONTAINER]}" docker rm -f "$CONTAINER_ID" >/dev/null 2>&1
+    cleanup_test_device
+}

--- a/test/local_test_runner/lib/_run-test.bash
+++ b/test/local_test_runner/lib/_run-test.bash
@@ -78,14 +78,14 @@ run_test() {
     # Run unit tests if neither --coverage nor --workflow were passed
     if [[ "${CONFIG[COVERAGE]}" == "false" && "${CONFIG[WORKFLOW]}" == "false" ]]; then
         echo "🧪 Running BATS tests: ${test_file}"
-        run_inner_harness "bats '${CONFIG[BATS_FLAGS]}' '${test_file}'"
+        run_systemd_container "bats '${CONFIG[BATS_FLAGS]}' '${test_file}'"
     fi
 
     # Run kcov inside Docker if --coverage is enabled
     if [[ "${CONFIG[COVERAGE]}" == "true" ]]; then
         echo "📊 Running coverage analysis..."
         local coverage_output
-        coverage_output=$(run_inner_harness "kcov_dir=\$(mktemp -d) && \
+        coverage_output=$(run_systemd_container "kcov_dir=\$(mktemp -d) && \
                        kcov --clean --include-path='${source_file}' \"\$kcov_dir\" bats '${test_file}' > /dev/null 2>&1 && \
                        cat \"\$kcov_dir/bats/sonarqube.xml\"")
 
@@ -100,7 +100,7 @@ run_test() {
     # Run workflow tests if --workflow was passed
     if [[ "${CONFIG[WORKFLOW]}" == "true" ]]; then
         echo "🚀 Running workflow tests for job: ${workflow_job}"
-        run_inner_harness "act \
+        run_systemd_container "act \
                         '${workflow_event}' \
                         -P ${CONFIG[ACT_MAPPING]} \
                         --pull=false \

--- a/test/local_test_runner/runner.bash
+++ b/test/local_test_runner/runner.bash
@@ -78,11 +78,22 @@ load_libraries() {
     source "$BASEDIR/test/local_test_runner/lib/_runner-config.bash"
     source "$BASEDIR/test/local_test_runner/lib/_parser.bash"
     source "$BASEDIR/test/local_test_runner/lib/_manage_outer_docker.bash"
-    source "$BASEDIR/test/local_test_runner/lib/_run-inner-harness.bash"
+    #source "$BASEDIR/test/local_test_runner/lib/_run-inner-harness.bash"
     source "$BASEDIR/test/local_test_runner/lib/_run-test.bash"
+    source "$BASEDIR/test/local_test_runner/lib/_run-inner-sysd.bash"
 }
 
-test_systemd_container() {
+test_inner_systemd_container() {
+    local source_file=""
+    local test_file="${CONFIG[BASE_DIR]}/test/local_test_runner/unit/inner_systemd_container/smoke_test.bats"
+    local workflow_event=""
+    local workflow_job=""
+
+    #file_check "$source_file" "$test_file" || return 1
+
+    run_test "$source_file" "$test_file" "$workflow_event" "$workflow_job"
+}
+xtest_systemd_container() {
     # point the outer container at the systemd container instead of test container
     CONFIG[HARNESS_IMAGE]="robertportelli/readiluks-systemd-inner:latest"
     # this is manual debugging test

--- a/test/local_test_runner/unit/inner_systemd_container/smoke_test.bats
+++ b/test/local_test_runner/unit/inner_systemd_container/smoke_test.bats
@@ -1,22 +1,62 @@
+# test/local_test_runner/unit/inner_systemd_container/smoke_test.bats
+
 function setup {
     load '../../../lib/_common_setup'
     _common_setup
-    source "test/local_test_runner/lib/_runner-config.bash"
-    source "test/local_test_runner/lib/_manage_outer_docker.bash"
-}
-
-@test "smoke test systemd container" {
-    run start_outer_container
-    assert_success
 }
 
 @test "systemd is running" {
-    start_outer_container
-
-    run docker exec -it "${CONFIG[OUTER_CONTAINER]}" \
-        docker exec -it "${CONFIG[SYSTEMD_CONTAINER]}" \
-        systemctl is-system-running
-
+    run systemctl is-system-running
     assert_success
     assert_output -p "running"
+}
+
+@test "create hello.service unit file" {
+    bash -c 'cat <<EOF > /etc/systemd/system/hello.service
+[Unit]
+Description=Hello World Service
+
+[Service]
+ExecStart=/bin/echo "Hello from systemd"
+
+[Install]
+WantedBy=multi-user.target
+EOF'
+    run test -f /etc/systemd/system/hello.service
+    assert_success
+}
+
+@test "reload systemd units" {
+    run systemctl daemon-reload
+    assert_success
+}
+
+@test "enable hello.service" {
+    run systemctl enable hello.service
+    assert_success
+    assert_output -p "Created symlink"
+}
+
+@test "start hello.service" {
+    run systemctl start hello.service
+    assert_success
+}
+
+@test "hello.service is inactive after exit" {
+    run systemctl is-active hello.service
+    assert_failure
+    assert_output -p "inactive" # echo is not a persistent process
+}
+
+
+@test "hello.service is enabled" {
+    run systemctl is-enabled hello.service
+    assert_success
+    assert_output -p "enabled"
+}
+
+@test "journal contains hello output" {
+    run journalctl -u hello.service --no-pager
+    assert_success
+    assert_output -p "Hello from systemd"
 }


### PR DESCRIPTION
This PR completes the migration from the legacy inner harness container to a new, systemd-native test strategy built around ephemeral containers. The updated system is more faithful to real-world service orchestration and lays the groundwork for robust integration testing.

## ✨ Highlights

- **New test runner**: Introduces `_run-inner-sysd.bash` to launch ephemeral systemd containers inside the Docker-in-Docker environment, mount loopback devices, and run tests in isolation.
- **Systemd lifecycle smoke test**: Fully rewrites `smoke_test.bats` to create, start, and verify a real `hello.service` unit using `systemctl`, including journal output assertions.
- **Updated test orchestration**: Replaces `run_inner_harness` with `run_systemd_container` across all test types, including Bats unit tests, coverage analysis, and workflow invocation.
- **CI alignment**: Updates GitHub Actions workflows to run on `readiluks-inner-systemd:latest` instead of the deprecated harness image.
- **Makefile update**: Corrects the build target and path to use the finalized inner systemd Dockerfile.
- **Systemd image provisioning**: Installs all required tooling (`bats-*`, `lvm2`, `btrfs-progs`, `kcov`, `act`, etc.) into the systemd container for parity with local and CI test environments.

## ✅ Benefits

- Eliminates reliance on the inner harness container
- Enables more realistic, systemd-native test execution
- Ensures a clean environment per test via ephemeral container strategy
- Simplifies the outer orchestrator by deferring systemd container lifecycle to test-time
- Makes integration with `systemd-analyze`, `journalctl`, and mount/unit testing possible

This PR represents a major infrastructure upgrade to the `readiluks` test framework and sets the stage for LUKS, LVM, and mount unit tests to follow.

- **feat(test): add systemd container test runner with loopback support**
- **feat(docker): provision inner systemd container with full test dependencies**
- **chore(ci): migrate test workflows to use inner systemd container**
- **refactor(test): disable harness image and long-running systemd container startup**
- **refactor(test): replace inner harness test execution with systemd container runner**
- **refactor(test): introduce test_inner_systemd_container entry point and wire up systemd runner**
- **test(systemd): expand smoke test with real systemd unit lifecycle validation**
- **chore(makefile): update inner systemd container build target to match renamed image**
